### PR TITLE
Specify dir for  `p35_*.gdx` dump

### DIFF
--- a/R/iterativeEDGETransport.R
+++ b/R/iterativeEDGETransport.R
@@ -10,6 +10,7 @@
 #'
 iterativeEdgeTransport <- function() {
   print(paste("---", Sys.time(), "Start of the EDGE-T iterative model run."))
+  print(paste("---", Sys.time(), "Working directory:", getwd()))
 
   #############################################################
   ## Settings
@@ -549,7 +550,7 @@ iterativeEdgeTransport <- function() {
 
   ## CapCosts
   gdxdt::writegdx.parameter(
-    "p35_esCapCost.gdx",
+    file.path(getwd(), "p35_esCapCost.gdx"),
     f35_esCapCost,
     "p35_esCapCost",
     valcol = "value",
@@ -558,7 +559,7 @@ iterativeEdgeTransport <- function() {
 
   ## Intensities
   gdxdt::writegdx.parameter(
-    "p35_fe2es.gdx",
+    file.path(getwd(), "p35_fe2es.gdx"),
     f35_fe2es,
     "p35_fe2es",
     valcol = "value",
@@ -567,7 +568,7 @@ iterativeEdgeTransport <- function() {
 
   ## Shares: demand can represent the shares since it is normalized
   gdxdt::writegdx.parameter(
-    "p35_shFeCes.gdx",
+    file.path(getwd(), "p35_shFeCes.gdx"),
     f35_shFeCes,
     "p35_shFeCes",
     valcol = "value",

--- a/R/iterativeEDGETransport.R
+++ b/R/iterativeEDGETransport.R
@@ -10,7 +10,7 @@
 #'
 iterativeEdgeTransport <- function() {
   print(paste("---", Sys.time(), "Start of the EDGE-T iterative model run."))
-  print(paste("---", Sys.time(), "Working directory:", getwd()))
+  print(paste("Working directory:", getwd()))
 
   #############################################################
   ## Settings


### PR DESCRIPTION
Makes sure that ``p35_*.gdx` file dump at the end of edge transport simulation are written into *current working dir* via `getwd()`. This should work for REMIND runs as wd is the current REMIND run folder

## Purpose of this PR

## Checklist:

- [x] I used ./test-standard-runs to compare and archive the changes introduced by this PR in /p/projects/edget/PRchangeLog/

Instructions for PIK internal testing of transport packages:

  1.  Navigate to this folder on the cluster `/p/projects/edget/PRchangeLog/`
  2.  Run the following command in the folder: `./test-standard-runs "FolderName" "ReferenceFolder"`, where "FolderName" is a name you can choose which identifies your changes or PR, i.e. the PR number plus a keyword. "ReferenceFolder" is an optional argument and should be a folder that already exists in the directory "/p/projects/edget/PRchangeLog/". If not set this defaults to the last stored run. 
      Running this command submits four sbatch jobs. You can optionally find a help page by running ./test-standard-runs -h
  3.  You are now interactively asked if repositories should be installed from source. Here, name one after another all the repositories in which you introduced changes. You can for example use your GitHub branch for that.
  4.  Wait until the submitted jobs have finished and check if the folders "ChangeLogMix[1-4]" have been generated and hold a compScen each.  You can check the `testScen[1-4]_edgetPR*.out` files in case of errors.
  5.  Check the compScen if you wish to review changes of the results compared to the reference run.


## Further information (optional):

* Test runs are here: 
* Comparison of results (what changes by this PR?): 

